### PR TITLE
📈 (Outbound link tracking) Update `vuepress-plugin-plausible` to 0.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14395,7 +14395,7 @@
     },
     "node_modules/vuepress-plugin-plausible": {
       "version": "0.0.2",
-      "resolved": "git+ssh://git@github.com/tecladocode/vuepress-plugin-plausible.git#d28b1963ce25233b6eb1f3566d5c60acf47f8f4f",
+      "resolved": "git+ssh://git@github.com/tecladocode/vuepress-plugin-plausible.git#7da43abc8ba97f21ab9f13455dac00787464771b",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -26827,7 +26827,7 @@
       }
     },
     "vuepress-plugin-plausible": {
-      "version": "git+ssh://git@github.com/tecladocode/vuepress-plugin-plausible.git#d28b1963ce25233b6eb1f3566d5c60acf47f8f4f",
+      "version": "git+ssh://git@github.com/tecladocode/vuepress-plugin-plausible.git#7da43abc8ba97f21ab9f13455dac00787464771b",
       "from": "vuepress-plugin-plausible@github:tecladocode/vuepress-plugin-plausible"
     },
     "vuepress-plugin-smooth-scroll": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "dependencies": {
         "markdown-it-footnote": "^3.0.3",
         "markdown-it-task-lists": "^2.1.1",
-        "vuepress-plugin-plausible": "github:tecladocode/vuepress-plugin-plausible"
+        "vuepress-plugin-plausible": "^0.0.3"
       },
       "devDependencies": {
         "surge": "^0.21.7",
@@ -14394,9 +14394,9 @@
       }
     },
     "node_modules/vuepress-plugin-plausible": {
-      "version": "0.0.2",
-      "resolved": "git+ssh://git@github.com/tecladocode/vuepress-plugin-plausible.git#7da43abc8ba97f21ab9f13455dac00787464771b",
-      "license": "MIT",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/vuepress-plugin-plausible/-/vuepress-plugin-plausible-0.0.3.tgz",
+      "integrity": "sha512-Axsa9VBAiVD8W0VvHWn6iQ2D5pS7hnzIsVBYj1GfjxnZVod09OIVEwP/c9++8ABtix95A1OgA6KNI4BskBx3zw==",
       "engines": {
         "node": ">=8"
       }
@@ -26827,8 +26827,9 @@
       }
     },
     "vuepress-plugin-plausible": {
-      "version": "git+ssh://git@github.com/tecladocode/vuepress-plugin-plausible.git#7da43abc8ba97f21ab9f13455dac00787464771b",
-      "from": "vuepress-plugin-plausible@github:tecladocode/vuepress-plugin-plausible"
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/vuepress-plugin-plausible/-/vuepress-plugin-plausible-0.0.3.tgz",
+      "integrity": "sha512-Axsa9VBAiVD8W0VvHWn6iQ2D5pS7hnzIsVBYj1GfjxnZVod09OIVEwP/c9++8ABtix95A1OgA6KNI4BskBx3zw=="
     },
     "vuepress-plugin-smooth-scroll": {
       "version": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
   "dependencies": {
     "markdown-it-footnote": "^3.0.3",
     "markdown-it-task-lists": "^2.1.1",
-    "vuepress-plugin-plausible": "github:tecladocode/vuepress-plugin-plausible"
+    "vuepress-plugin-plausible": "^0.0.3"
   }
 }


### PR DESCRIPTION
This adds outbound link tracking option in the vuepress config.